### PR TITLE
escape < and & in attributes

### DIFF
--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -210,7 +210,7 @@ def html_escape(s):
     return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 def attr_escape(s):
-    return s.replace('"', "&quot;")
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace('"', "&quot;")
 
 def dict_to_attrs(dct):
     lst = []
@@ -224,7 +224,7 @@ def dict_to_attrs(dct):
                     repr(type(value))
                 )
             )
-        escaped_value = replace('"', "&quot;")
+        escaped_value = attr_escape(value)
         if key == 'klass':
             lst.append('class="%s"' % escaped_value)
         else:


### PR DESCRIPTION
doc.stag was not escaping < and &

patched attr_escape to always escape < and & which is required according to:

http://www.w3.org/TR/xml/#NT-AttValue

also use attr_escape in dict_to_attrs
