### PR TITLE
Alternative class attribute implementation

### DIFF
--- a/tests/tests_simpledoc.py
+++ b/tests/tests_simpledoc.py
@@ -1,5 +1,6 @@
 import unittest
 from yattag import SimpleDoc
+from yattag.simpledoc import ClassValue
 import xml.etree.ElementTree as ET
 
 class TestSimpledoc(unittest.TestCase):
@@ -39,18 +40,18 @@ class TestSimpledoc(unittest.TestCase):
 
     def test_html_classes(self):
         def class_elems(node):
-            return set(node.attrib['class'].split(' '))
+            return set(node.attrib['class'].split())
 
         doc, tag, text = SimpleDoc().tagtext()
 
         with tag('p', klass = 'news'):
-            doc.add_class('highlight', 'today')
-            doc.remove_class('news')
-            doc.toggle_class('active')
+            doc.classes.add('highlight today')
+            doc.classes.remove('news')
+            doc.classes.toggle('active')
             with tag('a', href = '/', klass = 'small useless'):
-                doc.remove_class('useless')
+                doc.classes.remove('useless')
             with tag('a', href = '/', klass = 'important'):
-                doc.remove_class('important')
+                doc.classes.remove('important')
         
         root = ET.fromstring(doc.getvalue())
         self.assertEqual(
@@ -62,6 +63,28 @@ class TestSimpledoc(unittest.TestCase):
             set(['small'])
         )
         self.assertRaises(KeyError, lambda: class_elems(root[1]))
+
+class ClassValueTests(unittest.TestCase):
+    def test_toggle(self):
+        classes = ClassValue('bc')
+
+        classes.toggle('a')
+        self.assertEqual(str(classes), 'a b c')
+
+        classes.toggle('a')
+        self.assertEqual(str(classes), 'b c')
+
+        classes.toggle('a', True)
+        self.assertEqual(str(classes), 'a b c')
+
+        classes.toggle('a', True)
+        self.assertEqual(str(classes), 'a b c')
+
+        classes.toggle('a', False)
+        self.assertEqual(str(classes), 'b c')
+
+        classes.toggle('a', False)
+        self.assertEqual(str(classes), 'b c')
 
 if __name__ == '__main__':
     unittest.main()

--- a/yattag/doc.py
+++ b/yattag/doc.py
@@ -1,4 +1,4 @@
-from yattag.simpledoc import dict_to_attrs, html_escape, attr_escape, SimpleDoc, DocError
+from yattag.simpledoc import dict_to_attrs, html_escape, attr_escape, update_class_attr, SimpleDoc, DocError
 
 try:
     range = xrange  # for Python 2/3 compatibility
@@ -23,10 +23,7 @@ class SimpleInput(object):
         attrs = dict(self.attrs)
         error = errors and self.name in errors
         if error:
-            if 'class' in attrs:
-                attrs['class'] = attrs['class'] + " error"
-            else:
-                attrs['class'] = "error"
+            attrs['class'].add('error')
             lst.append(error_wrapper[0])
             lst.append(html_escape(errors[self.name]))
             lst.append(error_wrapper[1])
@@ -59,8 +56,7 @@ class CheckableInput(object):
                     lst.append(error_wrapper[0])
                     lst.append(html_escape(errors[self.name]))
                     lst.append(error_wrapper[1])
-                    if 'class' not in attrs:
-                        attrs['class'] = "error"
+                    attrs['class'].add('error')
         
         if self.name in defaults and 'value' in self.attrs and defaults[self.name] == self.attrs['value']:
             attrs['checked'] = 'checked'
@@ -111,8 +107,7 @@ class ContainerTag(object):
                 lst.append(error_wrapper[0])
                 lst.append(html_escape(errors[self.name]))
                 lst.append(error_wrapper[1])
-            if 'class' not in attrs:
-                attrs['class'] = "error"
+            attrs['class'].add('error')
         attrs['name'] = self.name
 
         lst.append('<%s %s>' % (self.__class__.tag_name, dict_to_attrs(attrs)))
@@ -183,10 +178,9 @@ def _attrs_from_args(required_keys, *args, **kwargs):
             attrs[arg[0]] = arg[1]
         else:
             raise_exception(arg)
-    attrs.update(
-        (('class', value) if key == 'klass' else (key, value))
-        for key, value in kwargs.items()
-    )
+
+    attrs.update(kwargs)
+    update_class_attr(attrs)
 
     required_attrs = []
 


### PR DESCRIPTION
What exactly changed from the user side:

```
doc.add_class('highlight', 'today')  -> doc.classes.add('highlight today')
doc.remove_class('news')             -> doc.classes.remove('news')
doc.toggle_class('active')           -> doc.classes.toggle('active')
```

Main benefit from this change is ability to use full power of python's built-in
`set()` instead of restricted `add_class`, `remove_class`, `toggle_class` api.
Also, users are not forced to learn new apis it is enaugh to tell, that
`doc.classes` is a `set()` and everyone should know what to do with it.

Internally `class` attribute is always `set()` so it simplifies internal code
too. There is no need to convert string to set and set back to string for each
operation.
