### PR TITLE
Convert text value to string on html_escape

### DIFF
--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -263,7 +263,9 @@ class DocError(Exception):
     pass
           
 def html_escape(s):
-    return str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    if isinstance(s,(int,float)):
+        return str(s)
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 def attr_escape(s):
     try:

--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -263,7 +263,7 @@ class DocError(Exception):
     pass
           
 def html_escape(s):
-    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 def attr_escape(s):
     try:


### PR DESCRIPTION
Explicitly cast **html_escape()** arg as a string to prevent an AttributeError when passing ints/floats to **text()**