### PR TITLE
Allow attributes of value None which won't be rendered

### DIFF
--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -296,7 +296,7 @@ def dict_to_attrs(dct):
     return ' '.join(
         (key if value is ATTR_NO_VALUE
         else '%s="%s"' % (key, attr_escape(value)))
-        for key,value in dct.items()
+        for key,value in dct.items() if value != None
     )
     
 def _attributes(args, kwargs):


### PR DESCRIPTION
Very helpful when you don't want to specify default attributes:

```
enctype = None
for field in form:
    if isinstance(field, FileField):
        enctype = "multipart/form-data"

with tag("form", method="post", enctype=enctype):
    ...
```
