### PR TITLE
HTML5 W3C Stag Style Compliance

### DIFF
--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -4,7 +4,7 @@ class SimpleDoc(object):
 
     """
     class generating xml/html documents using context managers
-    
+
     doc, tag, text = SimpleDoc().tagtext()
 
     with tag('html'):
@@ -14,20 +14,20 @@ class SimpleDoc(object):
 
     print(doc.getvalue())
     """
-            
+
     class Tag(object):
         def __init__(self, doc, name, attrs): # name is the tag name (ex: 'div')
-            
+
             self.doc = doc
             self.name = name
             self.attrs = attrs
-            
+
         def __enter__(self):
             self.parent_tag = self.doc.current_tag
             self.doc.current_tag = self
             self.position = len(self.doc.result)
             self.doc._append('')
-            
+
         def __exit__(self, tpe, value, traceback):
             if value is None:
                 if self.attrs:
@@ -39,7 +39,7 @@ class SimpleDoc(object):
                     self.doc.result[self.position] = "<%s>" % self.name
                 self.doc._append("</%s>" % self.name)
                 self.doc.current_tag = self.parent_tag
-         
+
     class DocumentRoot(object):
         def __getattr__(self, item):
             raise DocError("DocumentRoot here. You can't access anything here.")
@@ -48,7 +48,7 @@ class SimpleDoc(object):
         self.result = []
         self.current_tag = self.__class__.DocumentRoot()
         self._append = self.result.append
-        
+
     def tag(self, tag_name, *args, **kwargs):
         """
         opens a HTML/XML tag for use inside a `with` statement
@@ -58,89 +58,89 @@ class SimpleDoc(object):
         The values of the keyword arguments should be strings.
         They are escaped for use as HTML attributes
         (the " character is replaced with &quot;)
-        
+
         In order to supply a "class" html attributes, you must supply a `klass` keyword
         argument. This is because `class` is a reserved python keyword so you can't use it
-        outside of a class definition. 
-        
+        outside of a class definition.
+
         Example::
-        
+
             with tag('h1', id = 'main-title'):
                 text("Hello world!")
-                
+
             # <h1 id="main-title">Hello world!</h1> was appended to the document
-            
+
             with tag('td',
                 ('data-search', 'lemon'),
                 ('data-order', '1384'),
                 id = '16'
             ):
                 text('Citrus Limon')
-                
+
             # you get: <td data-search="lemon" data-order="1384" id="16">Citrus Limon</td>
-                
-            
+
+
         """
         return self.__class__.Tag(self, tag_name, _attributes(args, kwargs))
 
-        
+
     def text(self, *strgs):
         """
         appends 0 or more strings to the document
-        the strings are escaped for use as text in html documents, that is, 
+        the strings are escaped for use as text in html documents, that is,
         & becomes &amp;
         < becomes &lt;
         > becomes &gt;
-        
+
         Example::
-        
+
             username = 'Max'
             text('Hello ', username, '!') # appends "Hello Max!" to the current node
             text('16 > 4') # appends "16 &gt; 4" to the current node
         """
         for strg in strgs:
             self._append(html_escape(strg))
-            
+
     def line(self, tag_name, text_content, *args, **kwargs):
         """
         Shortcut to write tag nodes that contain only text.
         For example, in order to obtain::
-        
+
             <h1>The 7 secrets of catchy titles</h1>
-            
+
         you would write::
-            
+
             line('h1', 'The 7 secrets of catchy titles')
-            
+
         which is just a shortcut for::
-        
+
             with tag('h1'):
                 text('The 7 secrets of catchy titles')
-                
+
         The first argument is the tag name, the second argument
         is the text content of the node.
         The optional arguments after that are interpreted as xml/html
         attributes. in the same way as with the `tag` method.
-        
+
         Example::
-        
+
             line('a', 'Who are we?', href = '/about-us.html')
-            
+
         produces::
-            
+
             <a href="/about-us.html">Who are we?</a>
         """
         with self.tag(tag_name, *args, **kwargs):
-            self.text(text_content) 
-        
+            self.text(text_content)
+
     def asis(self, *strgs):
         """
         appends 0 or more strings to the documents
         contrary to the `text` method, the strings are appended "as is"
         &, < and > are NOT escaped
-        
+
         Example::
-        
+
             doc.asis('<!DOCTYPE html>') # appends <!DOCTYPE html> to the document
         """
         for strg in strgs:
@@ -149,10 +149,10 @@ class SimpleDoc(object):
                 # passing None by mistake was frequent enough to justify a check
                 # see https://github.com/leforestier/yattag/issues/20
             self._append(strg)
-        
+
     def nl(self):
         self._append('\n')
-        
+
     def attr(self, *args, **kwargs):
         """
         sets HTML/XML attribute(s) on the current tag
@@ -163,33 +163,33 @@ class SimpleDoc(object):
         (the " character is replaced with &quot;)
         Note that, instead, you can set html/xml attributes by passing them as
         keyword arguments to the `tag` method.
-        
+
         In order to supply a "class" html attributes, you can either pass
         a ('class', 'my_value') pair, or supply a `klass` keyword argument
         (this is because `class` is a reserved python keyword so you can't use it
         outside of a class definition).
-        
+
         Examples::
-            
+
             with tag('h1'):
                 text('Welcome!')
                 doc.attr(id = 'welcome-message', klass = 'main-title')
-            
+
             # you get: <h1 id="welcome-message" class="main-title">Welcome!</h1>
-        
+
             with tag('td'):
                 text('Citrus Limon')
                 doc.attr(
                     ('data-search', 'lemon'),
                     ('data-order', '1384')
                 )
-                
-                
+
+
             # you get: <td data-search="lemon" data-order="1384">Citrus Limon</td>
-        
+
         """
         self.current_tag.attrs.update(_attributes(args, kwargs))
-        
+
     def stag(self, tag_name, *args, **kwargs):
         """
         appends a self closing tag to the document
@@ -198,27 +198,27 @@ class SimpleDoc(object):
         The values of the keyword arguments should be strings.
         They are escaped for use as HTML attributes
         (the " character is replaced with &quot;)
-        
+
         Example::
-        
+
             doc.stag('img', src = '/salmon-plays-piano.jpg')
-            # appends <img src="/salmon-plays-piano.jpg /> to the document
+            # appends <img src="/salmon-plays-piano.jpg"> to the document
         """
         if args or kwargs:
-            self._append("<%s %s />" % (
+            self._append("<%s %s>" % (
                 tag_name,
                 dict_to_attrs(_attributes(args, kwargs)),
             ))
         else:
-            self._append("<%s />" % tag_name)
-            
+            self._append("<%s>" % tag_name)
+
     def cdata(self, strg, safe = False):
         """
         appends a CDATA section containing the supplied string
-        
+
         You don't have to worry about potential ']]>' sequences that would terminate
         the CDATA section. They are replaced with ']]]]><![CDATA[>'.
-        
+
         If you're sure your string does not contain ']]>', you can pass `safe = True`.
         If you do that, your string won't be searched for ']]>' sequences.
         """
@@ -228,32 +228,32 @@ class SimpleDoc(object):
         else:
             self._append(strg.replace(']]>', ']]]]><![CDATA[>'))
         self._append(']]>')
-            
+
     def getvalue(self):
         """
         returns the whole document as a single string
         """
         return ''.join(self.result)
-        
+
     def tagtext(self):
         """
         return a triplet composed of::
             . the document itself
             . its tag method
             . its text method
-        
+
         Example::
-        
+
             doc, tag, text = SimpleDoc().tagtext()
-            
+
             with tag('h1'):
                 text('Hello world!')
-                
+
             print(doc.getvalue()) # prints <h1>Hello world!</h1>
         """
-            
+
         return self, self.tag, self.text
-        
+
     def ttl(self):
         """
         returns a quadruplet composed of::
@@ -261,16 +261,16 @@ class SimpleDoc(object):
             . its tag method
             . its text method
             . its line method
-            
+
         Example::
-        
+
             doc, tag, text, line = SimpleDoc().ttl()
-            
+
             with tag('ul', id='grocery-list'):
                 line('li', 'Tomato sauce', klass="priority")
                 line('li', 'Salt')
                 line('li', 'Pepper')
-                
+
             print(doc.getvalue())
         """
         return self, self.tag, self.text, self.line
@@ -284,15 +284,15 @@ class SimpleDoc(object):
                 if not user_logged_in:
                     doc.add_class('restricted-area')
                 text("Our new product")
-            
+
             print(doc.getvalue())
 
             # prints <a class="restricted-area small" href="/nuclear-device"></a>
-        """ 
+        """
         self._set_classes(
             self._get_classes().union(classes)
         )
-    
+
     def discard_class(self, *classes):
         """
         remove one or many elements from the html "class" attribute of the current
@@ -304,9 +304,9 @@ class SimpleDoc(object):
 
     def toggle_class(self, elem, active):
         """
-        if active is a truthy value, ensure elem is present inside the html 
+        if active is a truthy value, ensure elem is present inside the html
         "class" attribute of the current tag, otherwise (if active is falsy)
-        ensure elem is absent 
+        ensure elem is absent
         """
         classes = self._get_classes()
         if active:
@@ -314,7 +314,7 @@ class SimpleDoc(object):
         else:
             classes.discard(elem)
         self._set_classes(classes)
-    
+
 
     def _get_classes(self):
         try:
@@ -335,7 +335,7 @@ class SimpleDoc(object):
 
 class DocError(Exception):
     pass
-          
+
 def html_escape(s):
     if isinstance(s,(int,float)):
         return str(s)
@@ -345,8 +345,8 @@ def html_escape(s):
         raise TypeError(
             "You can only insert a string, an int or a float inside a xml/html text node. "
             "Got %s (type %s) instead." % (repr(s), repr(type(s)))
-        )   
-        
+        )
+
 
 def attr_escape(s):
     if isinstance(s,(int,float)):
@@ -358,7 +358,7 @@ def attr_escape(s):
             "xml/html attributes should be passed as strings, ints or floats. "
             "Got %s (type %s) instead." % (repr(s), repr(type(s)))
         )
-    
+
 
 ATTR_NO_VALUE = object()
 
@@ -368,7 +368,7 @@ def dict_to_attrs(dct):
         else '%s="%s"' % (key, attr_escape(value)))
         for key,value in dct.items()
     )
-    
+
 def _attributes(args, kwargs):
     lst = []
     for arg in args:
@@ -387,5 +387,3 @@ def _attributes(args, kwargs):
         for key,value in kwargs.items()
     )
     return result
-
-

--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -4,7 +4,7 @@ class SimpleDoc(object):
 
     """
     class generating xml/html documents using context managers
-
+    
     doc, tag, text = SimpleDoc().tagtext()
 
     with tag('html'):
@@ -14,20 +14,20 @@ class SimpleDoc(object):
 
     print(doc.getvalue())
     """
-
+            
     class Tag(object):
         def __init__(self, doc, name, attrs): # name is the tag name (ex: 'div')
-
+            
             self.doc = doc
             self.name = name
             self.attrs = attrs
-
+            
         def __enter__(self):
             self.parent_tag = self.doc.current_tag
             self.doc.current_tag = self
             self.position = len(self.doc.result)
             self.doc._append('')
-
+            
         def __exit__(self, tpe, value, traceback):
             if value is None:
                 if self.attrs:
@@ -39,7 +39,7 @@ class SimpleDoc(object):
                     self.doc.result[self.position] = "<%s>" % self.name
                 self.doc._append("</%s>" % self.name)
                 self.doc.current_tag = self.parent_tag
-
+         
     class DocumentRoot(object):
         def __getattr__(self, item):
             raise DocError("DocumentRoot here. You can't access anything here.")
@@ -48,7 +48,7 @@ class SimpleDoc(object):
         self.result = []
         self.current_tag = self.__class__.DocumentRoot()
         self._append = self.result.append
-
+        
     def tag(self, tag_name, *args, **kwargs):
         """
         opens a HTML/XML tag for use inside a `with` statement
@@ -58,89 +58,89 @@ class SimpleDoc(object):
         The values of the keyword arguments should be strings.
         They are escaped for use as HTML attributes
         (the " character is replaced with &quot;)
-
+        
         In order to supply a "class" html attributes, you must supply a `klass` keyword
         argument. This is because `class` is a reserved python keyword so you can't use it
-        outside of a class definition.
-
+        outside of a class definition. 
+        
         Example::
-
+        
             with tag('h1', id = 'main-title'):
                 text("Hello world!")
-
+                
             # <h1 id="main-title">Hello world!</h1> was appended to the document
-
+            
             with tag('td',
                 ('data-search', 'lemon'),
                 ('data-order', '1384'),
                 id = '16'
             ):
                 text('Citrus Limon')
-
+                
             # you get: <td data-search="lemon" data-order="1384" id="16">Citrus Limon</td>
-
-
+                
+            
         """
         return self.__class__.Tag(self, tag_name, _attributes(args, kwargs))
 
-
+        
     def text(self, *strgs):
         """
         appends 0 or more strings to the document
-        the strings are escaped for use as text in html documents, that is,
+        the strings are escaped for use as text in html documents, that is, 
         & becomes &amp;
         < becomes &lt;
         > becomes &gt;
-
+        
         Example::
-
+        
             username = 'Max'
             text('Hello ', username, '!') # appends "Hello Max!" to the current node
             text('16 > 4') # appends "16 &gt; 4" to the current node
         """
         for strg in strgs:
             self._append(html_escape(strg))
-
+            
     def line(self, tag_name, text_content, *args, **kwargs):
         """
         Shortcut to write tag nodes that contain only text.
         For example, in order to obtain::
-
+        
             <h1>The 7 secrets of catchy titles</h1>
-
+            
         you would write::
-
+            
             line('h1', 'The 7 secrets of catchy titles')
-
+            
         which is just a shortcut for::
-
+        
             with tag('h1'):
                 text('The 7 secrets of catchy titles')
-
+                
         The first argument is the tag name, the second argument
         is the text content of the node.
         The optional arguments after that are interpreted as xml/html
         attributes. in the same way as with the `tag` method.
-
+        
         Example::
-
+        
             line('a', 'Who are we?', href = '/about-us.html')
-
+            
         produces::
-
+            
             <a href="/about-us.html">Who are we?</a>
         """
         with self.tag(tag_name, *args, **kwargs):
-            self.text(text_content)
-
+            self.text(text_content) 
+        
     def asis(self, *strgs):
         """
         appends 0 or more strings to the documents
         contrary to the `text` method, the strings are appended "as is"
         &, < and > are NOT escaped
-
+        
         Example::
-
+        
             doc.asis('<!DOCTYPE html>') # appends <!DOCTYPE html> to the document
         """
         for strg in strgs:
@@ -149,10 +149,10 @@ class SimpleDoc(object):
                 # passing None by mistake was frequent enough to justify a check
                 # see https://github.com/leforestier/yattag/issues/20
             self._append(strg)
-
+        
     def nl(self):
         self._append('\n')
-
+        
     def attr(self, *args, **kwargs):
         """
         sets HTML/XML attribute(s) on the current tag
@@ -163,33 +163,33 @@ class SimpleDoc(object):
         (the " character is replaced with &quot;)
         Note that, instead, you can set html/xml attributes by passing them as
         keyword arguments to the `tag` method.
-
+        
         In order to supply a "class" html attributes, you can either pass
         a ('class', 'my_value') pair, or supply a `klass` keyword argument
         (this is because `class` is a reserved python keyword so you can't use it
         outside of a class definition).
-
+        
         Examples::
-
+            
             with tag('h1'):
                 text('Welcome!')
                 doc.attr(id = 'welcome-message', klass = 'main-title')
-
+            
             # you get: <h1 id="welcome-message" class="main-title">Welcome!</h1>
-
+        
             with tag('td'):
                 text('Citrus Limon')
                 doc.attr(
                     ('data-search', 'lemon'),
                     ('data-order', '1384')
                 )
-
-
+                
+                
             # you get: <td data-search="lemon" data-order="1384">Citrus Limon</td>
-
+        
         """
         self.current_tag.attrs.update(_attributes(args, kwargs))
-
+        
     def stag(self, tag_name, *args, **kwargs):
         """
         appends a self closing tag to the document
@@ -198,27 +198,27 @@ class SimpleDoc(object):
         The values of the keyword arguments should be strings.
         They are escaped for use as HTML attributes
         (the " character is replaced with &quot;)
-
+        
         Example::
-
+        
             doc.stag('img', src = '/salmon-plays-piano.jpg')
-            # appends <img src="/salmon-plays-piano.jpg"> to the document
+            # appends <img src="/salmon-plays-piano.jpg /> to the document
         """
         if args or kwargs:
-            self._append("<%s %s>" % (
+            self._append("<%s %s />" % (
                 tag_name,
                 dict_to_attrs(_attributes(args, kwargs)),
             ))
         else:
-            self._append("<%s>" % tag_name)
-
+            self._append("<%s />" % tag_name)
+            
     def cdata(self, strg, safe = False):
         """
         appends a CDATA section containing the supplied string
-
+        
         You don't have to worry about potential ']]>' sequences that would terminate
         the CDATA section. They are replaced with ']]]]><![CDATA[>'.
-
+        
         If you're sure your string does not contain ']]>', you can pass `safe = True`.
         If you do that, your string won't be searched for ']]>' sequences.
         """
@@ -228,32 +228,32 @@ class SimpleDoc(object):
         else:
             self._append(strg.replace(']]>', ']]]]><![CDATA[>'))
         self._append(']]>')
-
+            
     def getvalue(self):
         """
         returns the whole document as a single string
         """
         return ''.join(self.result)
-
+        
     def tagtext(self):
         """
         return a triplet composed of::
             . the document itself
             . its tag method
             . its text method
-
+        
         Example::
-
+        
             doc, tag, text = SimpleDoc().tagtext()
-
+            
             with tag('h1'):
                 text('Hello world!')
-
+                
             print(doc.getvalue()) # prints <h1>Hello world!</h1>
         """
-
+            
         return self, self.tag, self.text
-
+        
     def ttl(self):
         """
         returns a quadruplet composed of::
@@ -261,16 +261,16 @@ class SimpleDoc(object):
             . its tag method
             . its text method
             . its line method
-
+            
         Example::
-
+        
             doc, tag, text, line = SimpleDoc().ttl()
-
+            
             with tag('ul', id='grocery-list'):
                 line('li', 'Tomato sauce', klass="priority")
                 line('li', 'Salt')
                 line('li', 'Pepper')
-
+                
             print(doc.getvalue())
         """
         return self, self.tag, self.text, self.line
@@ -284,15 +284,15 @@ class SimpleDoc(object):
                 if not user_logged_in:
                     doc.add_class('restricted-area')
                 text("Our new product")
-
+            
             print(doc.getvalue())
 
             # prints <a class="restricted-area small" href="/nuclear-device"></a>
-        """
+        """ 
         self._set_classes(
             self._get_classes().union(classes)
         )
-
+    
     def discard_class(self, *classes):
         """
         remove one or many elements from the html "class" attribute of the current
@@ -304,9 +304,9 @@ class SimpleDoc(object):
 
     def toggle_class(self, elem, active):
         """
-        if active is a truthy value, ensure elem is present inside the html
+        if active is a truthy value, ensure elem is present inside the html 
         "class" attribute of the current tag, otherwise (if active is falsy)
-        ensure elem is absent
+        ensure elem is absent 
         """
         classes = self._get_classes()
         if active:
@@ -314,7 +314,7 @@ class SimpleDoc(object):
         else:
             classes.discard(elem)
         self._set_classes(classes)
-
+    
 
     def _get_classes(self):
         try:
@@ -335,7 +335,7 @@ class SimpleDoc(object):
 
 class DocError(Exception):
     pass
-
+          
 def html_escape(s):
     if isinstance(s,(int,float)):
         return str(s)
@@ -345,8 +345,8 @@ def html_escape(s):
         raise TypeError(
             "You can only insert a string, an int or a float inside a xml/html text node. "
             "Got %s (type %s) instead." % (repr(s), repr(type(s)))
-        )
-
+        )   
+        
 
 def attr_escape(s):
     if isinstance(s,(int,float)):
@@ -358,7 +358,7 @@ def attr_escape(s):
             "xml/html attributes should be passed as strings, ints or floats. "
             "Got %s (type %s) instead." % (repr(s), repr(type(s)))
         )
-
+    
 
 ATTR_NO_VALUE = object()
 
@@ -368,7 +368,7 @@ def dict_to_attrs(dct):
         else '%s="%s"' % (key, attr_escape(value)))
         for key,value in dct.items()
     )
-
+    
 def _attributes(args, kwargs):
     lst = []
     for arg in args:
@@ -387,3 +387,5 @@ def _attributes(args, kwargs):
         for key,value in kwargs.items()
     )
     return result
+
+

--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -202,15 +202,15 @@ class SimpleDoc(object):
         Example::
         
             doc.stag('img', src = '/salmon-plays-piano.jpg')
-            # appends <img src="/salmon-plays-piano.jpg /> to the document
+            # appends <img src="/salmon-plays-piano.jpg"> to the document
         """
         if args or kwargs:
-            self._append("<%s %s />" % (
+            self._append("<%s %s>" % (
                 tag_name,
                 dict_to_attrs(_attributes(args, kwargs)),
             ))
         else:
-            self._append("<%s />" % tag_name)
+            self._append("<%s>" % tag_name)
             
     def cdata(self, strg, safe = False):
         """


### PR DESCRIPTION
https://www.w3.org/TR/html5/forms.html#the-input-element
https://www.w3.org/TR/html5/text-level-semantics.html#the-br-element

Both show a stag style without the closing slash e.g. `<br>` rather than `<br />`.

I can't foresee any real problems in terms of browser support.