### PR TITLE
Add data attribute method to simpledoc

### DIFF
--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -233,9 +233,10 @@ class SimpleDoc(object):
             # you get: <td data-search="lemon" data-order="1384">Citrus Limon</td>
         
         """
-        args = [('data-%s' % key, value) for (key, value) in args]
-        kwargs = {('data-%s' % key): value for (key, value) in kwargs.items()}
-        self.current_tag.attrs.update(_attributes(args, kwargs))
+        self.attr(
+            *(('data-%s' % key, value) for (key, value) in args),
+            **dict(('data-%s' % key, value) for (key, value) in kwargs.items())
+        )
         
     def stag(self, tag_name, *args, **kwargs):
         """

--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -203,6 +203,40 @@ class SimpleDoc(object):
         """
         self.current_tag.attrs.update(_attributes(args, kwargs))
         
+    def data(self, *args, **kwargs):
+        """
+        sets HTML/XML data attribute(s) on the current tag
+        HTML/XML data attributes are supplied as (key, value) pairs of strings,
+        or as keyword arguments.
+        The values of the keyword arguments should be strings.
+        They are escaped for use as HTML attributes
+        (the " character is replaced with &quot;)
+        Note that, instead, you can set html/xml data attributes by passing them as
+        keyword arguments to the `tag` method.
+        
+        Examples::
+            
+            with tag('h1'):
+                text('Welcome!')
+                doc.data(msg='welcome-message')
+            
+            # you get: <h1 data-msg="welcome-message">Welcome!</h1>
+        
+            with tag('td'):
+                text('Citrus Limon')
+                doc.data(
+                    ('search', 'lemon'),
+                    ('order', '1384')
+                )
+                
+                
+            # you get: <td data-search="lemon" data-order="1384">Citrus Limon</td>
+        
+        """
+        args = [('data-%s' % key, value) for (key, value) in args]
+        kwargs = {('data-%s' % key): value for (key, value) in kwargs.items()}
+        self.current_tag.attrs.update(_attributes(args, kwargs))
+        
     def stag(self, tag_name, *args, **kwargs):
         """
         appends a self closing tag to the document


### PR DESCRIPTION
This PR adds a `simpledoc.data` method that adds HTML5 data attributes to the current tag. The method is called in the same way as `simpledoc.attr`. It takes keyword arguments or (key, value) pairs, prefixes each key with "data-", then updates the current tag with the new attributes.

The commit also includes documentation on the method, adapted from the documentation of `simpledoc.attr`