### PR TITLE
Type hints: add flag file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ with open('README.rst') as fd:
 setup(
     name='yattag',
     version='1.13.0',
+    package_data={"yattag": ["py.typed"]},
     packages=['yattag'],
     install_requires=[
         'typing',


### PR DESCRIPTION
See
<https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages>
for documentation, this is necessary, otherwise mypy won't look at type
comments from external code.

Related to #54 