### PR TITLE
Install typing backport only for python versions < 3.5 as it cause is…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     package_data={"yattag": ["py.typed"]},
     packages=['yattag'],
     install_requires=[
-        'typing',
+        'typing;python_version<"3.5"',
     ],
     author = 'Benjamin Le Forestier',
     author_email = 'benjamin@leforestier.org',


### PR DESCRIPTION
…sues e.g. in python 3.7