### PR TITLE
updated input list to include 'file' and 'tel' types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ __pycache__
 MANIFEST
 dist/
 build/
-
+settings.json

--- a/test/tests_doc.py
+++ b/test/tests_doc.py
@@ -94,7 +94,7 @@ class TestDoc(unittest.TestCase):
             KeyError, lambda: root[0].attrib['checked']
         )
 
-    def test_other_input_types(self):
+    def test_file_and_tel_input_types(self):
         doc, tag, text = Doc().tagtext()
         with tag('body'):
             doc.input(name='test', type='file')
@@ -103,8 +103,17 @@ class TestDoc(unittest.TestCase):
         self.assertEqual(
             root[0].attrib['type'],'file'
         )
-        self.assertTrue(
+        self.assertEqual(
             root[1].attrib['type'], 'tel'
+        )
+        
+    def test_file_input_with_default_error(self):
+        doc, tag, text = Doc(defaults= {"test":'notastreamhandler'}).tagtext()
+        with self.assertRaises(Exception) as context:
+             doc.input(name='test', type='file')
+
+        self.assertTrue(
+            'Default value for HTML form input of type "file" is not supported' in str(context.exception)
         )
 
     def test_input_checkbox(self):

--- a/test/tests_doc.py
+++ b/test/tests_doc.py
@@ -93,7 +93,20 @@ class TestDoc(unittest.TestCase):
         self.assertRaises(
             KeyError, lambda: root[0].attrib['checked']
         )
-        
+
+    def test_other_input_types(self):
+        doc, tag, text = Doc().tagtext()
+        with tag('body'):
+            doc.input(name='test', type='file')
+            doc.input(name='test2', type='tel')
+        root = ET.fromstring(doc.getvalue())
+        self.assertEqual(
+            root[0].attrib['type'],'file'
+        )
+        self.assertTrue(
+            root[1].attrib['type'], 'tel'
+        )
+
     def test_input_checkbox(self):
         doc, tag, text = Doc(defaults = {'gift-wrap': 'yes'}).tagtext()
         with tag('body'):

--- a/yattag/doc.py
+++ b/yattag/doc.py
@@ -39,6 +39,9 @@ class SimpleInput(object):
             lst.append(error_wrapper[1])
                 
         if self.name in defaults:
+            if(self.tpe == 'file'):
+                raise DocError('Default value for HTML form input of type "file" is not supported')
+
             attrs['value'] = str(defaults[self.name])
         attrs['name'] = self.name
         lst.append('<input type="%s" %s%s' % (self.tpe, dict_to_attrs(attrs), stag_end))

--- a/yattag/doc.py
+++ b/yattag/doc.py
@@ -412,7 +412,7 @@ class Doc(SimpleDoc):
         name, type, attrs = _attrs_from_args(('name', 'type'), *args, **kwargs)
         self._fields.add(name)
         if type in (
-            'text', 'password', 'hidden', 'search', 'email', 'url', 'number',
+            'text','file','tel', 'password', 'hidden', 'search', 'email', 'url', 'number',
             'range', 'date', 'datetime', 'datetime-local', 'month', 'week',
             'time', 'color'
         ): 


### PR DESCRIPTION
I saw an issue about not including a file type for Simple_Input, so I added it and 'tel' to the list as options. I also added an additional test to make sure it functioned correctly.