### PR TITLE
Fixed typo within README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Html form rendering
 -------------------
 
 Yattag can fill your HTML forms with default values and error messages.
-Pass a ``defaults`` dictionnary of default values, and an ``errors`` dictionnary of error messages to the ``Doc`` constructor.
+Pass a ``defaults`` dictionary of default values, and an ``errors`` dictionary of error messages to the ``Doc`` constructor.
 Then, use the special ``input``, ``textarea``, ``select``, ``option`` methods when generating your documents.
 
 


### PR DESCRIPTION
"dictionnary" was just changed to "dictionary", this is just a typo I found. Although, I'm unsure of whether or not "dictionary" is spelled differently in specific locations.