### PR TITLE
Use 'phor' to give tags the 'for' attribute.

### DIFF
--- a/test/test_simpledoc.py
+++ b/test/test_simpledoc.py
@@ -24,6 +24,9 @@ class TestSimpledoc(unittest.TestCase):
             with tag('a', ('data-my-id', '89'), klass='alert'):
                 text('hi')
             doc.stag('img', src='squirrel.jpg', klass='animal')
+            doc.stag('input', type='radio', id='RadioId')
+            with tag('label', phor='RadioId'):
+                text('Radio Button')
 
         root = ET.fromstring(doc.getvalue())
         self.assertEqual(root.attrib['class'], "new")
@@ -31,9 +34,16 @@ class TestSimpledoc(unittest.TestCase):
         self.assertEqual(root[0].attrib['data-my-id'], '89')
         self.assertEqual(root[1].attrib['src'], 'squirrel.jpg')
         self.assertEqual(root[1].attrib['class'], 'animal')
+        self.assertEqual(root[2].attrib['type'], 'radio')
+        self.assertEqual(root[2].attrib['id'], 'RadioId')
+        self.assertEqual(root[3].attrib['for'], 'RadioId')
         self.assertRaises(
             KeyError,
             lambda: root[1].attrib['klass']
+        )
+        self.assertRaises(
+            KeyError,
+            lambda: root[3].attrib['phor']
         )
 
     def test_attrs_no_value(self):

--- a/yattag/doc.py
+++ b/yattag/doc.py
@@ -1,4 +1,4 @@
-from yattag.simpledoc import dict_to_attrs, html_escape, attr_escape, SimpleDoc, DocError
+from yattag.simpledoc import dict_to_attrs, _attr_key_translations, html_escape, attr_escape, SimpleDoc, DocError
 from typing import Any
 from typing import Dict
 from typing import List
@@ -230,7 +230,7 @@ def _attrs_from_args(required_keys, *args, **kwargs):
         else:
             raise_exception(arg)
     attrs.update(
-        (('class', value) if key == 'klass' else (key, value))
+        (_attr_key_translations.get(key, key), value)
         for key, value in kwargs.items()
     )
 

--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -113,9 +113,11 @@ class SimpleDoc(object):
         They are escaped for use as HTML attributes
         (the " character is replaced with &quot;)
 
-        In order to supply a "class" html attributes, you must supply a `klass` keyword
-        argument. This is because `class` is a reserved python keyword so you can't use it
-        outside of a class definition.
+        The names of some HTML attributes are reserved keywords in Python. Special names
+        are made to translate to them. Currently, there are:
+
+        `klass` -> `class`
+        `phor`  -> `for`
 
         Example::
 
@@ -254,10 +256,14 @@ class SimpleDoc(object):
         Note that, instead, you can set html/xml attributes by passing them as
         keyword arguments to the `tag` method.
 
-        In order to supply a "class" html attributes, you can either pass
-        a ('class', 'my_value') pair, or supply a `klass` keyword argument
-        (this is because `class` is a reserved python keyword so you can't use it
-        outside of a class definition).
+        The names of some HTML attributes are reserved keywords in Python. Special names
+        are made to translate to them. Currently, there are:
+
+        `klass` -> `class`
+        `phor`  -> `for`
+
+        Alternately, their real name can be passed as a tuple, such as
+        ('class', 'my_value')
 
         Examples::
 
@@ -266,6 +272,12 @@ class SimpleDoc(object):
                 doc.attr(id = 'welcome-message', klass = 'main-title')
 
             # you get: <h1 id="welcome-message" class="main-title">Welcome!</h1>
+
+            doc.stag('input', type='radio', id='RadioId')
+            with tag('label', phor='RadioId'):
+                text('Radio Button')
+
+            # you get: <input type="radio" id="RadioId" /><label for="RadioId">Radio Button</label>
 
             with tag('td'):
                 text('Citrus Limon')
@@ -517,6 +529,11 @@ def dict_to_attrs(dct):
         for key,value in dct.items()
     )
 
+_attr_key_translations = {
+    'klass' : 'class',
+    'phor'  : 'for'
+}
+
 def _attributes(args, kwargs):
     # type: (Any, Any) -> Dict[str, Any]
     lst = [] # type: List[Any]
@@ -532,7 +549,7 @@ def _attributes(args, kwargs):
             )
     result = dict(lst)
     result.update(
-        (('class', value) if key == 'klass' else (key, value))
+        (_attr_key_translations.get(key, key), value)
         for key,value in kwargs.items()
     )
     return result


### PR DESCRIPTION
'for' is another reserved keyword like 'class', and will not work as a keyword parameter for 'tag()', 'stag()', etc'. Allow 'phor' to be passed to specify the 'for' attribute, instead. Additionally, the new structure of the code will allow more substitutions to be easily added by placing entries in the dict '_attr_key_translations' in 'simpledoc.py'