### PR TITLE
Add exports to _all__

### DIFF
--- a/yattag/__init__.py
+++ b/yattag/__init__.py
@@ -56,6 +56,14 @@ Full tutorial on yattag.org_
 
 __author__ = "Benjamin Le Forestier (benjamin@leforestier.org)"
 __version__ = '1.15.1'
+__all__ = [
+    'Doc',
+    'SimpleDoc',
+    'indent',
+    'NO',
+    'FIRST_LINE',
+    'EACH_LINE'
+]
 
 from yattag.simpledoc import SimpleDoc
 from yattag.doc import Doc


### PR DESCRIPTION
Currently pyright is throwing this error in VSCode when attempting to import modules from `yattag` using `from yattag import {module_name}`. To remove this, `__all__` can be used to explicitly define the intended exports.

https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportPrivateImportUsage
```
reportPrivateImportUsage [boolean or string, optional]: Generate or suppress diagnostics for use of a symbol from a "py.typed" module that is not meant to be exported from that module. The default value for this setting is "error".
```