### PR TITLE
Added AsIs for inserting un-escaped strings as attribute values.

### DIFF
--- a/test/test_simpledoc.py
+++ b/test/test_simpledoc.py
@@ -2,6 +2,8 @@ import unittest
 from yattag import SimpleDoc, AsIs
 import xml.etree.ElementTree as ET
 
+from yattag.simpledoc import format_attr_value
+
 class TestSimpledoc(unittest.TestCase):
 
     def test_tag(self):
@@ -159,11 +161,36 @@ class TestSimpledoc(unittest.TestCase):
         doc.text("&")
         self.assertEqual(doc.getvalue(), "&amp;")
 
-    def test_asis(self):
+    def test_asis_double_quotes(self):
         doc, tag, text = SimpleDoc().tagtext()
-        with tag('elem', data=AsIs("{'a':'b'}")):
+        with tag('elem', data=AsIs("\"{'a':'b'}\"")):
             pass
         self.assertEqual(doc.getvalue(), "<elem data=\"{'a':'b'}\"></elem>")
+
+    def test_asis_single_quotes(self):
+        doc, tag, text = SimpleDoc().tagtext()
+        with tag('elem', data=AsIs("\'{\"a\":\"b\"}'")):
+            pass
+        self.assertEqual(doc.getvalue(), "<elem data='{\"a\":\"b\"}'></elem>")
+
+
+class TestFormatAttrValue(unittest.TestCase):
+    def test_str(self):
+        self.assertEqual(format_attr_value('hello'), '"hello"')
+
+    def test_int(self):
+        self.assertEqual(format_attr_value(42), '"42"')
+
+    def test_float(self):
+        self.assertEqual(format_attr_value(4.2), '"4.2"')
+
+    def test_asis_unwrapped(self):
+        self.assertEqual(format_attr_value(AsIs('hello')), 'hello')
+
+    def test_asis_wrapped(self):
+        self.assertEqual(format_attr_value(AsIs('\"hello\"')), '\"hello\"')
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_simpledoc.py
+++ b/test/test_simpledoc.py
@@ -1,5 +1,5 @@
 import unittest
-from yattag import SimpleDoc
+from yattag import SimpleDoc, AsIs
 import xml.etree.ElementTree as ET
 
 class TestSimpledoc(unittest.TestCase):
@@ -158,6 +158,12 @@ class TestSimpledoc(unittest.TestCase):
         doc = SimpleDoc()
         doc.text("&")
         self.assertEqual(doc.getvalue(), "&amp;")
+
+    def test_asis(self):
+        doc, tag, text = SimpleDoc().tagtext()
+        with tag('elem', data=AsIs("{'a':'b'}")):
+            pass
+        self.assertEqual(doc.getvalue(), "<elem data=\"{'a':'b'}\"></elem>")
 
 if __name__ == '__main__':
     unittest.main()

--- a/yattag/__init__.py
+++ b/yattag/__init__.py
@@ -59,12 +59,13 @@ __version__ = '1.15.2'
 __all__ = [
     'Doc',
     'SimpleDoc',
+    'AsIs',
     'indent',
     'NO',
     'FIRST_LINE',
     'EACH_LINE'
 ]
 
-from yattag.simpledoc import SimpleDoc
+from yattag.simpledoc import SimpleDoc, AsIs
 from yattag.doc import Doc
 from yattag.indentation import indent, NO, FIRST_LINE, EACH_LINE

--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -504,7 +504,7 @@ class AsIs:
 
 def attr_escape(s):
     # type: (Union[str, int, float]) -> str
-    if isinstance(s,(int,float,AsIs)):
+    if isinstance(s,(int,float)):
         return str(s)
     try:
         return s.replace("&", "&amp;").replace("<", "&lt;").replace('"', "&quot;")
@@ -514,6 +514,23 @@ def attr_escape(s):
             "Got %s (type %s) instead." % (repr(s), repr(type(s)))
         )
 
+def format_attr_value(value):
+    # type: (Union[str, int, float, AsIs]) -> str
+    """
+    formats an attribute value
+
+    For AsIs instances, this simply returns the str() of the value. For others,
+    it returns the result of calling attr_escape() on the value, wrapped in
+    double-quotes.
+
+    return a string suitable for putting after the "=" in an attribute
+    assignment.
+    """
+    if isinstance(value, AsIs):
+        return str(value)
+    else:
+        return f"\"{attr_escape(value)}\""
+
 
 ATTR_NO_VALUE = object()
 
@@ -521,7 +538,7 @@ def dict_to_attrs(dct):
     # type: (Dict[str, Any]) -> str
     return ' '.join(
         (key if value is ATTR_NO_VALUE
-        else '%s="%s"' % (key, attr_escape(value)))
+        else '%s=%s' % (key, format_attr_value(value)))
         for key,value in dct.items()
     )
 

--- a/yattag/simpledoc.py
+++ b/yattag/simpledoc.py
@@ -494,9 +494,17 @@ def html_escape(s):
         )
 
 
+class AsIs:
+    def __init__(self, value):
+        self._value = value
+
+    def __str__(self):
+        return self._value
+
+
 def attr_escape(s):
     # type: (Union[str, int, float]) -> str
-    if isinstance(s,(int,float)):
+    if isinstance(s,(int,float,AsIs)):
         return str(s)
     try:
         return s.replace("&", "&amp;").replace("<", "&lt;").replace('"', "&quot;")


### PR DESCRIPTION
This is the core idea discussed in #81. 

While this works, it's limited in a small way. Since yattag always uses double-quotes around attribute values, people can't use unescaped double-quotes in the AsIs value. I think I see how to account for this, but I figured it might be a step too far for this PR.